### PR TITLE
🐛 Fix invalid json response body (Trailing comma)

### DIFF
--- a/internal/README.md
+++ b/internal/README.md
@@ -11,4 +11,4 @@ Links to miners listed in /internal/miners.json for convenience:
 # Announcement.json
 If your going to make your own announcement, increment the number in "number" by 1
 
-Tip: When writing announcements, it is recommended that you don't use emojicon 🔧📜🛠️⚠️🎉✅🐛🩹 (or at least don't overuse it, as some OS don't have certain emojicons.)
+Tip: When writing announcements, it is recommended that you don't use [emoji](https://en.wikipedia.org/wiki/Emoji) 🔧📜🛠️⚠️🎉✅🐛🩹 (or at least don't overuse it, as some OS don't support emoji or have certain emoji.)

--- a/internal/announcement.json
+++ b/internal/announcement.json
@@ -12,6 +12,6 @@
         "",
         "🔧 Under the hood",
         "Migrate from CodeQL v1 to CodeQL v2",
-        "minerLinks.txt is now README.md (SaladBind/internal/)",
+        "minerLinks.txt is now README.md (SaladBind/internal/)"
     ]
 }


### PR DESCRIPTION
### Pull Request
Type: Bug fix

### Bug overview
This bug is caused by invaild JSON, specifically the Trailing comma (a comma symbol that is typed after the last item of a list of elements.)
![image](https://user-images.githubusercontent.com/93124920/190949089-25085d94-9091-4750-a03c-3a78b1c10d6e.png)
> invalid json response body

![image](https://user-images.githubusercontent.com/93124920/190949205-2918c0da-da7c-4e63-b2da-f6e4f68987cf.png)
> a comma symbol that is typed after the last item of a list of elements.

#### annoucement.json (a9c4e570ba1404634b354b938d2cb8b57e63ab01)
Old Line 15:         "minerLinks.txt is now README.md (SaladBind/internal/)",
New Line 15        "minerLinks.txt is now README.md (SaladBind/internal/)"

/shrug, just have to remove that little comma there

### Noted
Release a new build of SaladBind is not required. (No more Final Final Final Release :trollface: )