### PR TITLE
🛠️ Improve DAG Updater + Miners Update

### DIFF
--- a/internal/alfurDagUpdater.js
+++ b/internal/alfurDagUpdater.js
@@ -12,14 +12,31 @@ async function getDag(coin) {
 }
 
 async function doTheStuff(){
-    const ethDag = Math.round(await getDag("ETH") * 1000);
+    //const ethDag = Math.round(await getDag("ETH") * 1000);
+    const ethDag = 2147483647;
     const etcDag = Math.round(await getDag("ETC") * 1000);
     const rvnDag = Math.round(await getDag("RVN") * 1000);
     const ergDag = Math.round(await getDag("ERG") * 1000);
+    //miners.algos.ethash = ethDag;
     miners.algos.ethash = ethDag;
     miners.algos.etchash = etcDag;
     miners.algos.kawpow = rvnDag;
     miners.algos.autolykos2 = ergDag;
+    console.log(`
+
+Algorithm overview:
+
+    Ethash      will work when VRAM is higher than   ${ethDag}
+    Etchash     will work when VRAM is higher than   ${etcDag}
+    Kawpow      will work when VRAM is higher than   ${rvnDag}
+    Autolykos2  will work when VRAM is higher than   ${ergDag}
+
+Please check if the result
+
+    `)
     fs.writeFileSync("./internal/miners.json", JSON.stringify(miners, null, 4));
+    console.log(`
+    Update DAG complete!
+    `)
 }
 doTheStuff();

--- a/internal/miners.json
+++ b/internal/miners.json
@@ -7,7 +7,8 @@
         "EQUI144_5": 2000,
         "autolykos2": 2545,
         "octopus": 7000,
-        "randomx": null
+        "randomx": null,
+        "ghostrider": null,
     },
     "miners": {
         "phoenixminer": {

--- a/internal/miners.json
+++ b/internal/miners.json
@@ -1,14 +1,14 @@
 {
     "algos": {
-        "ethash": 0,
-        "etchash": 3078,
-        "kawpow": 3563,
+        "ethash": 2147483647,
+        "etchash": 3086,
+        "kawpow": 3578,
         "beamv3": 2000,
         "EQUI144_5": 2000,
-        "autolykos2": 2545,
-        "octopus": 7000,
+        "autolykos2": 2548,
+        "octopus": 4720,
         "randomx": null,
-        "ghostrider": null,
+        "raptoreum": null
     },
     "miners": {
         "phoenixminer": {
@@ -42,8 +42,8 @@
         "trex": {
             "miner": "T-Rex",
             "download": {
-                "win32": "https://github.com/trexminer/T-Rex/releases/download/0.26.5/t-rex-0.26.5-win.zip",
-                "linux": "https://github.com/trexminer/T-Rex/releases/download/0.26.5/t-rex-0.26.5-linux.tar.gz"
+                "win32": "https://github.com/trexminer/T-Rex/releases/download/0.26.6/t-rex-0.26.6-win.zip",
+                "linux": "https://github.com/trexminer/T-Rex/releases/download/0.26.6/t-rex-0.26.6-linux.tar.gz"
             },
             "algos": [
                 "ethash",
@@ -60,7 +60,7 @@
                 "linux"
             ],
             "fee": 1,
-            "version": "0.26.5",
+            "version": "0.26.6",
             "parameters": {
                 "fileName": "t-rex",
                 "algo": "-a",
@@ -104,8 +104,8 @@
         "teamredminer": {
             "miner": "TeamRedMiner",
             "download": {
-                "win32": "https://github.com/todxx/teamredminer/releases/download/v0.10.2/teamredminer-v0.10.2-win.zip",
-                "linux": "https://github.com/todxx/teamredminer/releases/download/v0.10.2/teamredminer-v0.10.2-linux.tgz"
+                "win32": "https://github.com/todxx/teamredminer/releases/download/v0.10.3.1/teamredminer-v0.10.3.1-win.zip",
+                "linux": "https://github.com/todxx/teamredminer/releases/download/v0.10.3.1/teamredminer-v0.10.3.1-linux.tgz"
             },
             "algos": [
                 "ethash",
@@ -120,7 +120,7 @@
                 "linux"
             ],
             "fee": 2,
-            "version": "v0.10.2",
+            "version": "v0.10.3.1",
             "parameters": {
                 "fileName": "teamredminer",
                 "algo": "-a",
@@ -132,8 +132,8 @@
         "lolminer": {
             "miner": "lolMiner",
             "download": {
-                "win32": "https://github.com/Lolliedieb/lolMiner-releases/releases/download/1.55/lolMiner_v1.55_Win64.zip",
-                "linux": "https://github.com/Lolliedieb/lolMiner-releases/releases/download/1.55/lolMiner_v1.55_Lin64.tar.gz"
+                "win32": "https://github.com/Lolliedieb/lolMiner-releases/releases/download/1.59/lolMiner_v1.59a_Win64.zip",
+                "linux": "https://github.com/Lolliedieb/lolMiner-releases/releases/download/1.59/lolMiner_v1.59a_Lin64.tar.gz"
             },
             "algos": [
                 "ethash",
@@ -150,7 +150,7 @@
                 "linux"
             ],
             "fee": 1,
-            "version": "1.55",
+            "version": "1.59a",
             "parameters": {
                 "fileName": "lolMiner",
                 "algo": "--algo",
@@ -168,7 +168,7 @@
             },
             "algos": [
                 "randomx",
-                "ghostrider"
+                "raptoreum"
             ],
             "supports_cpu": true,
             "supported_gpus": [],


### PR DESCRIPTION
# Improve DAG Updater + Miners Update
⚠️ **Conflict have been fixed (9802ec02bb9df576c2128d44ff0dc2590097be7c)**
🛠️🔧

## 🛠️ Improve DAG Updater (c276ea363f6c79ba6e28df1df0e5fca1220ecb52)
Disable Ethash, and show you the algorithm overview
> **This update will not interfere with your current DAG updater automated task**
![image](https://user-images.githubusercontent.com/93124920/193614561-1ce00171-3deb-4cab-ba42-180eeeff676b.png)

## 🔧 Miners Update (b447463c3ed689f9b53378bbb234da4af7e4868e), (61a4d775f97404cf9ac759b963a4d52964869445)
Bumped lolMiner to v1.59a
Bumped TeamRedMiner to v0.10.3.1
Bumped Trex to 0.26.6